### PR TITLE
[feat] stratified KFold split 기능

### DIFF
--- a/utils/splitStratifiedDataset.py
+++ b/utils/splitStratifiedDataset.py
@@ -1,0 +1,63 @@
+import os
+import json
+import numpy as np
+import pandas as pd
+import argparse
+
+from tqdm import tqdm
+
+from iterstrat.ml_stratifiers import MultilabelStratifiedKFold
+
+path = os.path.dirname(os.path.abspath(__file__)) 
+data_path = os.path.join(path, '..', 'dataset')
+
+images_path = os.path.join(data_path, 'train')
+annotations_path = os.path.join(data_path, 'train.json')
+
+def main(args):
+    with open(annotations_path, 'r') as f:
+        train_json = json.loads(f.read())
+        images = train_json['images']
+        categories = train_json['categories']
+        annotations = train_json['annotations']
+
+    annotations_df = pd.DataFrame.from_dict(annotations)
+    x = images
+    y = [[0] * len(categories) for _ in range(len(images))]
+    for anno in annotations:
+        y[anno['image_id']][anno['category_id']] += 1
+
+    mskf = MultilabelStratifiedKFold(n_splits=args.n_split, shuffle=True)
+
+    path = args.path
+
+    if not os.path.exists(path):
+        os.mkdir(path)
+
+    for idx, (train_index, val_index) in tqdm(enumerate(mskf.split(x, y)), total=args.n_split):
+        train_dict = dict()
+        val_dict = dict()
+        for i in ['info', 'licenses', 'categories']:
+            train_dict[i] = train_json[i]
+            val_dict[i] = train_json[i]
+        train_dict['images'] = np.array(images)[train_index].tolist()
+        val_dict['images'] = np.array(images)[val_index].tolist()
+        train_dict['annotations'] = annotations_df[annotations_df['image_id'].isin(train_index)].to_dict('records')
+        val_dict['annotations'] = annotations_df[annotations_df['image_id'].isin(val_index)].to_dict('records')
+
+        train_dir = os.path.join(path, f'cv_train_{idx + 1}.json')
+        val_dir = os.path.join(path, f'cv_val_{idx + 1}.json')
+        with open(train_dir, 'w') as train_file:
+            json.dump(train_dict, train_file)
+
+        with open(val_dir, 'w') as val_file:
+            json.dump(val_dict, val_file)
+
+    print("Done Make files")
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--path', '-p', type=str, default=os.path.join(path, '..', 'dataset', 'stratified_kfold'))
+    parser.add_argument('--n_split', '-n', type=int, default=10)
+    arg = parser.parse_args()
+    main(arg)


### PR DESCRIPTION
토론게시판에 있는 규범님의 코드를 활용하여 저희 repo에 stratified KFold split 기능을 추가하였습니다.
|Origin data|Stratified data|
|:-:|:-:|
![image](https://user-images.githubusercontent.com/64190071/159897201-f902d4d5-09b2-491f-b62c-560aa06bc218.png)|![image](https://user-images.githubusercontent.com/64190071/159897253-3f53f7ef-3542-4678-8072-b7af3b5e78bf.png)|

위 사진과 같이 클래스별 비율이 동일한 것을 확인할 수 있습니다.

## 사용 방법
```
pip install iterative-stratification
```
관련 라이브러리를 설치하시고, 
```
python utils/splitStratifiedDataset.py
```
명령어를 입력하시면 split 됩니다.

argparse로 dataset의 path나 fold 수를 지정할 수 있습니다.