### PR TITLE
[feat] DetectoRS MAILAB baseline 코드

### DIFF
--- a/mmdetection/configs/KTH_DetectoRS_MAILAB/DetectoRS_MAILAB.py
+++ b/mmdetection/configs/KTH_DetectoRS_MAILAB/DetectoRS_MAILAB.py
@@ -1,0 +1,32 @@
+_base_ = [
+    'dataset.py',
+    'schedule.py',
+    'runtime.py',
+    'models.py'
+]
+# 총 epochs 사이즈
+runner = dict(max_epochs=14)
+
+# samples_per_gpu -> batch size라 생각하면 됨
+data = dict(
+    samples_per_gpu=2,
+    workers_per_gpu=2)
+
+checkpoint_config = dict(interval=-1)
+
+# 로그와 관련된 셋팅
+log_config = dict(
+    interval=50,
+    hooks=[
+        dict(type='TextLoggerHook'),
+        # dict(type='TensorboardLoggerHook'),
+        dict(type='WandbLoggerHook',
+                init_kwargs=dict(
+                    # 각각 자신에 맞춰서 Project이름 설정
+                    project= 'Taeha_Kim',
+                    name = 'DetectoRS_MAILAB_baseline'
+                ),
+            ),
+        dict(type='MlflowLoggerHook')
+    ])
+find_unused_parameters = True

--- a/mmdetection/configs/KTH_DetectoRS_MAILAB/Reference.md
+++ b/mmdetection/configs/KTH_DetectoRS_MAILAB/Reference.md
@@ -1,0 +1,1 @@
+https://github.com/MAILAB-Yonsei/capsule_endoscopy_detection/blob/master/mmdetection/configs/detectors_cascade_rcnn_r50_ms/cascade_rcnn_r50_fpn.py

--- a/mmdetection/configs/KTH_DetectoRS_MAILAB/cascade_rcnn_r50_fpn.py
+++ b/mmdetection/configs/KTH_DetectoRS_MAILAB/cascade_rcnn_r50_fpn.py
@@ -1,0 +1,179 @@
+# model settings
+model = dict(
+    type='CascadeRCNN',
+    backbone=dict(
+        type='ResNet',
+        depth=50,
+        num_stages=4,
+        out_indices=(0, 1, 2, 3),
+        frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
+        norm_eval=True,
+        style='pytorch',
+        init_cfg=dict(type='Pretrained', checkpoint='torchvision://resnet50')),
+    neck=dict(
+        type='FPN',
+        in_channels=[256, 512, 1024, 2048],
+        out_channels=256,
+        num_outs=5),
+    rpn_head=dict(
+        type='RPNHead',
+        in_channels=256,
+        feat_channels=256,
+        anchor_generator=dict(
+            type='AnchorGenerator',
+            scales=[8],
+            ratios=[0.5, 1.0, 2.0],
+            strides=[4, 8, 16, 32, 64]),
+        bbox_coder=dict(
+            type='DeltaXYWHBBoxCoder',
+            target_means=[.0, .0, .0, .0],
+            target_stds=[1.0, 1.0, 1.0, 1.0]),
+        loss_cls=dict(
+            type='CrossEntropyLoss', use_sigmoid=True, loss_weight=1.0),
+        loss_bbox=dict(type='SmoothL1Loss', beta=1.0 / 9.0, loss_weight=1.0)),
+    roi_head=dict(
+        type='CascadeRoIHead',
+        num_stages=3,
+        stage_loss_weights=[1, 0.5, 0.25],
+        bbox_roi_extractor=dict(
+            type='SingleRoIExtractor',
+            roi_layer=dict(type='RoIAlign', output_size=7, sampling_ratio=0),
+            out_channels=256,
+            featmap_strides=[4, 8, 16, 32]),
+        bbox_head=[
+            dict(
+                type='Shared2FCBBoxHead',
+                in_channels=256,
+                fc_out_channels=1024,
+                roi_feat_size=7,
+                num_classes=10,
+                bbox_coder=dict(
+                    type='DeltaXYWHBBoxCoder',
+                    target_means=[0., 0., 0., 0.],
+                    target_stds=[0.1, 0.1, 0.2, 0.2]),
+                reg_class_agnostic=True,
+                loss_cls=dict(
+                    type='CrossEntropyLoss',
+                    use_sigmoid=False,
+                    loss_weight=1.0),
+                loss_bbox=dict(type='SmoothL1Loss', beta=1.0,
+                               loss_weight=1.0)),
+            dict(
+                type='Shared2FCBBoxHead',
+                in_channels=256,
+                fc_out_channels=1024,
+                roi_feat_size=7,
+                num_classes=10,
+                bbox_coder=dict(
+                    type='DeltaXYWHBBoxCoder',
+                    target_means=[0., 0., 0., 0.],
+                    target_stds=[0.05, 0.05, 0.1, 0.1]),
+                reg_class_agnostic=True,
+                loss_cls=dict(
+                    type='CrossEntropyLoss',
+                    use_sigmoid=False,
+                    loss_weight=1.0),
+                loss_bbox=dict(type='SmoothL1Loss', beta=1.0,
+                               loss_weight=1.0)),
+            dict(
+                type='Shared2FCBBoxHead',
+                in_channels=256,
+                fc_out_channels=1024,
+                roi_feat_size=7,
+                num_classes=10,
+                bbox_coder=dict(
+                    type='DeltaXYWHBBoxCoder',
+                    target_means=[0., 0., 0., 0.],
+                    target_stds=[0.033, 0.033, 0.067, 0.067]),
+                reg_class_agnostic=True,
+                loss_cls=dict(
+                    type='CrossEntropyLoss',
+                    use_sigmoid=False,
+                    loss_weight=1.0),
+                loss_bbox=dict(type='SmoothL1Loss', beta=1.0, loss_weight=1.0))
+        ]),
+    # model training and testing settings
+    train_cfg=dict(
+        rpn=dict(
+            assigner=dict(
+                type='MaxIoUAssigner',
+                pos_iou_thr=0.7,
+                neg_iou_thr=0.3,
+                min_pos_iou=0.3,
+                match_low_quality=True,
+                ignore_iof_thr=-1),
+            sampler=dict(
+                type='RandomSampler',
+                num=256,
+                pos_fraction=0.5,
+                neg_pos_ub=-1,
+                add_gt_as_proposals=False),
+            allowed_border=0,
+            pos_weight=-1,
+            debug=False),
+        rpn_proposal=dict(
+            nms_pre=2000,
+            max_per_img=2000,
+            nms=dict(type='nms', iou_threshold=0.7),
+            min_bbox_size=0),
+        rcnn=[
+            dict(
+                assigner=dict(
+                    type='MaxIoUAssigner',
+                    pos_iou_thr=0.5,
+                    neg_iou_thr=0.5,
+                    min_pos_iou=0.5,
+                    match_low_quality=False,
+                    ignore_iof_thr=-1),
+                sampler=dict(
+                    type='RandomSampler',
+                    num=512,
+                    pos_fraction=0.25,
+                    neg_pos_ub=-1,
+                    add_gt_as_proposals=True),
+                pos_weight=-1,
+                debug=False),
+            dict(
+                assigner=dict(
+                    type='MaxIoUAssigner',
+                    pos_iou_thr=0.6,
+                    neg_iou_thr=0.6,
+                    min_pos_iou=0.6,
+                    match_low_quality=False,
+                    ignore_iof_thr=-1),
+                sampler=dict(
+                    type='RandomSampler',
+                    num=512,
+                    pos_fraction=0.25,
+                    neg_pos_ub=-1,
+                    add_gt_as_proposals=True),
+                pos_weight=-1,
+                debug=False),
+            dict(
+                assigner=dict(
+                    type='MaxIoUAssigner',
+                    pos_iou_thr=0.7,
+                    neg_iou_thr=0.7,
+                    min_pos_iou=0.7,
+                    match_low_quality=False,
+                    ignore_iof_thr=-1),
+                sampler=dict(
+                    type='RandomSampler',
+                    num=512,
+                    pos_fraction=0.25,
+                    neg_pos_ub=-1,
+                    add_gt_as_proposals=True),
+                pos_weight=-1,
+                debug=False)
+        ]),
+    test_cfg=dict(
+        rpn=dict(
+            nms_pre=1000,
+            max_per_img=1000,
+            nms=dict(type='nms', iou_threshold=0.7),
+            min_bbox_size=0),
+        rcnn=dict(
+            score_thr=0.05,
+            nms=dict(type='nms', iou_threshold=0.5),
+            max_per_img=100)))

--- a/mmdetection/configs/KTH_DetectoRS_MAILAB/dataset.py
+++ b/mmdetection/configs/KTH_DetectoRS_MAILAB/dataset.py
@@ -1,0 +1,60 @@
+# dataset settings
+
+dataset_type = 'CocoDataset'
+data_root = 'dataset2/'
+
+classes = ("General trash", "Paper", "Paper pack", "Metal", "Glass", 
+           "Plastic", "Styrofoam", "Plastic bag", "Battery", "Clothing")
+
+img_norm_cfg = dict(
+    mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
+train_pipeline = [
+    dict(type='LoadImageFromFile'),
+    dict(type='LoadAnnotations', with_bbox=True),
+    dict(type='Resize', img_scale=(512, 512), keep_ratio=True),
+    dict(type='RandomFlip', flip_ratio=0.5),
+    dict(type='Normalize', **img_norm_cfg),
+    dict(type='Pad', size_divisor=32),
+    dict(type='DefaultFormatBundle'),
+    dict(type='Collect', keys=['img', 'gt_bboxes', 'gt_labels']),
+]
+test_pipeline = [
+    dict(type='LoadImageFromFile'),
+    dict(
+        type='MultiScaleFlipAug',
+        img_scale=(512, 512),
+        flip=False,
+        transforms=[
+            dict(type='Resize', keep_ratio=True),
+            dict(type='RandomFlip'),
+            dict(type='Normalize', **img_norm_cfg),
+            dict(type='Pad', size_divisor=32),
+            dict(type='ImageToTensor', keys=['img']),
+            dict(type='Collect', keys=['img']),
+        ])
+]
+data = dict(
+    samples_per_gpu=8,
+    workers_per_gpu=2,
+    train=dict(
+        type=dataset_type,
+        ann_file=data_root + 'stratified_kfold/cv_train_1.json',
+        img_prefix=data_root,
+        pipeline=train_pipeline,
+        classes=classes,
+        ),
+    val=dict(
+        type=dataset_type,
+        ann_file=data_root + 'stratified_kfold/cv_val_1.json',
+        img_prefix=data_root,
+        pipeline=test_pipeline,
+        classes=classes,
+        ),
+    test=dict(
+        type=dataset_type,
+        ann_file=data_root + 'test.json',
+        img_prefix=data_root,
+        pipeline=test_pipeline,
+        classes=classes,
+        ))
+evaluation = dict(interval=1, metric='bbox', save_best='bbox_mAP_50')

--- a/mmdetection/configs/KTH_DetectoRS_MAILAB/models.py
+++ b/mmdetection/configs/KTH_DetectoRS_MAILAB/models.py
@@ -1,0 +1,30 @@
+_base_ = [
+    './cascade_rcnn_r50_fpn.py',
+]
+#detectors_cascade_rcnn_r50_1x_coco
+model = dict(
+    backbone=dict(
+        type='DetectoRS_ResNet',
+        conv_cfg=dict(type='ConvAWS'),
+        sac=dict(type='SAC', use_deform=True),
+        stage_with_sac=(False, True, True, True),
+        output_img=True),
+    neck=dict(
+        type='RFP',
+        rfp_steps=2,
+        aspp_out_channels=64,
+        aspp_dilations=(1, 3, 6, 1),
+        rfp_backbone=dict(
+            rfp_inplanes=256,
+            type='DetectoRS_ResNet',
+            depth=50,
+            num_stages=4,
+            out_indices=(0, 1, 2, 3),
+            frozen_stages=1,
+            norm_cfg=dict(type='BN', requires_grad=True),
+            norm_eval=True,
+            conv_cfg=dict(type='ConvAWS'),
+            sac=dict(type='SAC', use_deform=True),
+            stage_with_sac=(False, True, True, True),
+            pretrained='torchvision://resnet50',
+            style='pytorch')))

--- a/mmdetection/configs/KTH_DetectoRS_MAILAB/runtime.py
+++ b/mmdetection/configs/KTH_DetectoRS_MAILAB/runtime.py
@@ -1,0 +1,28 @@
+checkpoint_config = dict(interval=1)
+# yapf:disable
+log_config = dict(
+    interval=50,
+    hooks=[
+        dict(type='TextLoggerHook'),
+        # dict(type='TensorboardLoggerHook'),
+        dict(type='WandbLoggerHook',
+                init_kwargs=dict(
+                    project= 'Devlee247',
+                    name = 'name'
+                ),
+            ),
+        dict(type='MlflowLoggerHook')
+    ])
+# yapf:enable
+custom_hooks = [dict(type='NumClassCheckHook')]
+
+dist_params = dict(backend='nccl')
+log_level = 'INFO'
+load_from = None
+resume_from = None
+workflow = [('train', 1)]
+
+# disable opencv multithreading to avoid system being overloaded
+opencv_num_threads = 0
+# set multi-process start method as `fork` to speed up the training
+mp_start_method = 'fork'

--- a/mmdetection/configs/KTH_DetectoRS_MAILAB/schedule.py
+++ b/mmdetection/configs/KTH_DetectoRS_MAILAB/schedule.py
@@ -1,0 +1,13 @@
+# optimizer
+optimizer_config = dict(grad_clip=None)
+optimizer = dict(type='SGD', lr=0.02 / 8, momentum=0.9, weight_decay=0.0001)
+
+# learning policy
+lr_config = dict(
+    policy='step',
+    warmup='linear',
+    warmup_iters=500,
+    warmup_ratio=0.001,
+    step=[8, 11])
+runner = dict(type='EpochBasedRunner', max_epochs=12)
+


### PR DESCRIPTION
## 사용 모델 및 구조
DetectoRS cascade rcnn
backbone : DetectoRS ResNet50(RFP backbone 동일)
Configuration / Data augmentation / LR Scheduler 모두 MAILAB Baseline Code 참조

## 리더보드 점수 및 로컬 점수
리더보드 점수 : 0.4489
로컬 점수 : 0.511

## 사용 방법

Train
python mmdetection/tools/train.py mmdetection/configs/KTH_DetectoRS_MAILAB/DetectoRS_MAILAB.py --seed 42

Test
python mmdetection/tools/inference.py mmdetection/configs/KTH_DetectoRS_MAILAB/DetectoRS_MAILAB.py  best_bbox_mAP_50_epoch_10 --seed 42

## Reference
[MAILAB Baseline Code](https://github.com/MAILAB-Yonsei/capsule_endoscopy_detection/tree/master/mmdetection/configs/detectors_cascade_rcnn_r50_ms)