### PR TITLE
[feat] cascadeRCNN_swinL fold9 추가

### DIFF
--- a/mmdetection/configs/Inseo15/cascadeRCNN_swin_l_fpp_rpn_cosineRe_ms2_fold9.py
+++ b/mmdetection/configs/Inseo15/cascadeRCNN_swin_l_fpp_rpn_cosineRe_ms2_fold9.py
@@ -1,0 +1,32 @@
+_base_ = [
+    'dataset.py',
+    'schedule.py',
+    'runtime.py',
+    'models.py'
+]
+
+# 총 epochs 사이즈
+runner = dict(max_epochs=24)
+
+# samples_per_gpu -> batch size라 생각하면 됨
+data = dict(
+    samples_per_gpu=2,
+    workers_per_gpu=2)
+
+checkpoint_config = dict(interval=-1)
+
+# 로그와 관련된 셋팅
+log_config = dict(
+    interval=50,
+    hooks=[
+        dict(type='TextLoggerHook'),
+        # dict(type='TensorboardLoggerHook'),
+        dict(type='WandbLoggerHook',
+                init_kwargs=dict(
+                    # 각각 자신에 맞춰서 Project이름 설정
+                    project= 'Inseo_Lee',
+                    name = '[Inseo14]cascadeRCNN_swin_l_ms2_fold9'
+                ),
+            ),
+        dict(type='MlflowLoggerHook')
+    ])

--- a/mmdetection/configs/Inseo15/dataset.py
+++ b/mmdetection/configs/Inseo15/dataset.py
@@ -1,0 +1,136 @@
+# dataset settings
+
+dataset_type = 'CocoDataset'
+data_root = 'dataset/'
+
+classes = ("General trash", "Paper", "Paper pack", "Metal", "Glass", 
+           "Plastic", "Styrofoam", "Plastic bag", "Battery", "Clothing")
+
+multi_scale = [(w,w) for w in range(512, 1280+1, 128)]
+
+albu_train_transforms = [
+    dict(
+        type='OneOf',
+        transforms=[
+            dict(type='Flip',p=1.0),
+            dict(type='RandomRotate90',p=1.0)
+        ],
+        p = 0.1
+    ),
+    dict(
+        type='RandomBrightnessContrast',
+        brightness_limit=[0.1, 0.3],
+        contrast_limit=[0.1, 0.3],
+        p=0.2),
+    dict(type='RandomResizedCrop',height=1024, width=1024, scale=(0.5, 1.0), p=0.2),
+    dict(
+        type='OneOf',
+        transforms=[
+            dict(
+                type='ChannelShuffle',
+                p=1.0),
+            dict(
+                type='RandomGamma',
+                p=1.0),
+            dict(
+                type='RGBShift',
+                p=1.0)
+        ],
+        p=0.1),
+    dict(
+        type='OneOf',
+        transforms=[
+            dict(type='Blur', blur_limit=3, p=1.0),
+            dict(type='MedianBlur', blur_limit=3, p=1.0)
+        ],
+        p=0.1),
+    ]
+
+img_norm_cfg = dict(
+    mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
+train_pipeline = [
+    dict(type='LoadImageFromFile'),
+    dict(type='LoadAnnotations', with_bbox=True),
+    dict(
+        type='Resize', 
+        img_scale=multi_scale,
+        multiscale_mode='value',
+        keep_ratio=True,
+        ),
+    dict(type='RandomFlip', flip_ratio=0.5),
+    dict(
+    type='Albu',
+    transforms=albu_train_transforms,
+    bbox_params=dict(
+        type='BboxParams',
+        format='pascal_voc',
+        label_fields=['gt_labels'],
+        min_visibility=0.0,
+        filter_lost_elements=True),
+    keymap={
+        'img': 'image',
+        'gt_bboxes': 'bboxes'
+    },
+    update_pad_shape=False,
+    skip_img_without_anno=True
+    ),
+    dict(type='Normalize', **img_norm_cfg),
+    dict(type='Pad', size_divisor=32),
+    dict(type='DefaultFormatBundle'),
+    dict(type='Collect', keys=['img', 'gt_bboxes', 'gt_labels']),
+]
+val_pipeline = [
+    dict(type='LoadImageFromFile'),
+    dict(
+        type='MultiScaleFlipAug',
+        img_scale=(1024,1024),
+        flip=False,
+        transforms=[
+            dict(type='Resize', keep_ratio=True),
+            dict(type='RandomFlip'),
+            dict(type='Normalize', **img_norm_cfg),
+            dict(type='Pad', size_divisor=32),
+            dict(type='ImageToTensor', keys=['img']),
+            dict(type='Collect', keys=['img']),
+        ])
+]
+test_pipeline = [
+    dict(type='LoadImageFromFile'),
+    dict(
+        type='MultiScaleFlipAug',
+        img_scale=[(w,w) for w in range(512, 1280+1, 256)],
+        flip=True,
+        transforms=[
+            dict(type='Resize', keep_ratio=True),
+            dict(type='RandomFlip'),
+            dict(type='Normalize', **img_norm_cfg),
+            dict(type='Pad', size_divisor=32),
+            dict(type='ImageToTensor', keys=['img']),
+            dict(type='Collect', keys=['img']),
+        ])
+]
+data = dict(
+    samples_per_gpu=8,
+    workers_per_gpu=2,
+    train=dict(
+        type=dataset_type,
+        ann_file=data_root + 'train_fold9.json',
+        img_prefix=data_root,
+        pipeline=train_pipeline,
+        classes=classes,
+        ),
+    val=dict(
+        type=dataset_type,
+        ann_file=data_root + 'val_fold9.json',
+        img_prefix=data_root,
+        pipeline=val_pipeline,
+        classes=classes,
+        ),
+    test=dict(
+        type=dataset_type,
+        ann_file=data_root + 'test.json',
+        img_prefix=data_root,
+        pipeline=test_pipeline,
+        classes=classes,
+        ))
+evaluation = dict(interval=1, metric='bbox', save_best='bbox_mAP_50')

--- a/mmdetection/configs/Inseo15/models.py
+++ b/mmdetection/configs/Inseo15/models.py
@@ -1,0 +1,188 @@
+
+pretrained = 'https://github.com/SwinTransformer/storage/releases/download/v1.0.0/swin_large_patch4_window7_224_22k.pth'  # noqa
+
+model = dict(
+    type='CascadeRCNN',
+    backbone=dict(
+        type='SwinTransformer',
+        embed_dims=192,
+        depths=[2, 2, 18, 2],
+        num_heads=[6, 12, 24, 48],
+        window_size=7,
+        mlp_ratio=4,
+        qkv_bias=True,
+        qk_scale=None,
+        drop_rate=0.,
+        attn_drop_rate=0.,
+        drop_path_rate=0.2,
+        patch_norm=True,
+        out_indices=(0, 1, 2, 3),
+        with_cp=False,
+        convert_weights=True,
+        init_cfg=dict(type='Pretrained', checkpoint=pretrained)),
+    neck=dict(
+        type='FPN',
+        in_channels=[192, 384, 768, 1536],
+        out_channels=256,
+        num_outs=5),
+    rpn_head=dict(
+        type='RPNHead',
+        in_channels=256,
+        feat_channels=256,
+        anchor_generator=dict(
+            type='AnchorGenerator',
+            scales=[8],
+            ratios=[0.5, 1.0, 2.0],
+            strides=[4, 8, 16, 32, 64]),
+        bbox_coder=dict(
+            type='DeltaXYWHBBoxCoder',
+            target_means=[.0, .0, .0, .0],
+            target_stds=[1.0, 1.0, 1.0, 1.0]),
+        loss_cls=dict(
+            type='CrossEntropyLoss', use_sigmoid=True, loss_weight=1.0),
+        loss_bbox=dict(type='SmoothL1Loss', beta=1.0 / 9.0, loss_weight=1.0)),
+    roi_head=dict(
+        type='CascadeRoIHead',
+        num_stages=3,
+        stage_loss_weights=[1, 0.5, 0.25],
+        bbox_roi_extractor=dict(
+            type='SingleRoIExtractor',
+            roi_layer=dict(type='RoIAlign', output_size=7, sampling_ratio=0),
+            out_channels=256,
+            featmap_strides=[4, 8, 16, 32]),
+        bbox_head=[
+            dict(
+                type='Shared2FCBBoxHead',
+                in_channels=256,
+                fc_out_channels=1024,
+                roi_feat_size=7,
+                num_classes=10,
+                bbox_coder=dict(
+                    type='DeltaXYWHBBoxCoder',
+                    target_means=[0., 0., 0., 0.],
+                    target_stds=[0.1, 0.1, 0.2, 0.2]),
+                reg_class_agnostic=True,
+                loss_cls=dict(
+                    type='CrossEntropyLoss',
+                    use_sigmoid=False,
+                    loss_weight=1.0),
+                loss_bbox=dict(type='SmoothL1Loss', beta=1.0,
+                               loss_weight=1.0)),
+            dict(
+                type='Shared2FCBBoxHead',
+                in_channels=256,
+                fc_out_channels=1024,
+                roi_feat_size=7,
+                num_classes=10,
+                bbox_coder=dict(
+                    type='DeltaXYWHBBoxCoder',
+                    target_means=[0., 0., 0., 0.],
+                    target_stds=[0.05, 0.05, 0.1, 0.1]),
+                reg_class_agnostic=True,
+                loss_cls=dict(
+                    type='CrossEntropyLoss',
+                    use_sigmoid=False,
+                    loss_weight=1.0),
+                loss_bbox=dict(type='SmoothL1Loss', beta=1.0,
+                               loss_weight=1.0)),
+            dict(
+                type='Shared2FCBBoxHead',
+                in_channels=256,
+                fc_out_channels=1024,
+                roi_feat_size=7,
+                num_classes=10,
+                bbox_coder=dict(
+                    type='DeltaXYWHBBoxCoder',
+                    target_means=[0., 0., 0., 0.],
+                    target_stds=[0.033, 0.033, 0.067, 0.067]),
+                reg_class_agnostic=True,
+                loss_cls=dict(
+                    type='CrossEntropyLoss',
+                    use_sigmoid=False,
+                    loss_weight=1.0),
+                loss_bbox=dict(type='SmoothL1Loss', beta=1.0, loss_weight=1.0))
+        ]),
+    # model training and testing settings
+    train_cfg=dict(
+        rpn=dict(
+            assigner=dict(
+                type='MaxIoUAssigner',
+                pos_iou_thr=0.7,
+                neg_iou_thr=0.3,
+                min_pos_iou=0.3,
+                match_low_quality=True,
+                ignore_iof_thr=-1),
+            sampler=dict(
+                type='RandomSampler',
+                num=256,
+                pos_fraction=0.5,
+                neg_pos_ub=-1,
+                add_gt_as_proposals=False),
+            allowed_border=0,
+            pos_weight=-1,
+            debug=False),
+        rpn_proposal=dict(
+            nms_pre=2000,
+            max_per_img=2000,
+            nms=dict(type='nms', iou_threshold=0.7),
+            min_bbox_size=0),
+        rcnn=[
+            dict(
+                assigner=dict(
+                    type='MaxIoUAssigner',
+                    pos_iou_thr=0.5,
+                    neg_iou_thr=0.5,
+                    min_pos_iou=0.5,
+                    match_low_quality=False,
+                    ignore_iof_thr=-1),
+                sampler=dict(
+                    type='RandomSampler',
+                    num=512,
+                    pos_fraction=0.25,
+                    neg_pos_ub=-1,
+                    add_gt_as_proposals=True),
+                pos_weight=-1,
+                debug=False),
+            dict(
+                assigner=dict(
+                    type='MaxIoUAssigner',
+                    pos_iou_thr=0.6,
+                    neg_iou_thr=0.6,
+                    min_pos_iou=0.6,
+                    match_low_quality=False,
+                    ignore_iof_thr=-1),
+                sampler=dict(
+                    type='RandomSampler',
+                    num=512,
+                    pos_fraction=0.25,
+                    neg_pos_ub=-1,
+                    add_gt_as_proposals=True),
+                pos_weight=-1,
+                debug=False),
+            dict(
+                assigner=dict(
+                    type='MaxIoUAssigner',
+                    pos_iou_thr=0.7,
+                    neg_iou_thr=0.7,
+                    min_pos_iou=0.7,
+                    match_low_quality=False,
+                    ignore_iof_thr=-1),
+                sampler=dict(
+                    type='RandomSampler',
+                    num=512,
+                    pos_fraction=0.25,
+                    neg_pos_ub=-1,
+                    add_gt_as_proposals=True),
+                pos_weight=-1,
+                debug=False)
+        ]),
+    test_cfg=dict(
+        rpn=dict(
+            nms_pre=1000,
+            max_per_img=1000,
+            nms=dict(type='nms', iou_threshold=0.7),
+            min_bbox_size=0),
+        rcnn=dict(
+            score_thr=0.00,
+            nms=dict(type='nms', iou_threshold=0.5),
+            max_per_img=100)))

--- a/mmdetection/configs/Inseo15/runtime.py
+++ b/mmdetection/configs/Inseo15/runtime.py
@@ -1,0 +1,28 @@
+checkpoint_config = dict(interval=1)
+# yapf:disable
+log_config = dict(
+    interval=50,
+    hooks=[
+        dict(type='TextLoggerHook'),
+        # dict(type='TensorboardLoggerHook'),
+        dict(type='WandbLoggerHook',
+                init_kwargs=dict(
+                    project= 'Inseo_Lee',
+                    name = '[Inseo9]cascadeRCNN_swin_b_ms'
+                ),
+            ),
+        dict(type='MlflowLoggerHook')
+    ])
+# yapf:enable
+custom_hooks = [dict(type='NumClassCheckHook')]
+
+dist_params = dict(backend='nccl')
+log_level = 'INFO'
+load_from = None
+resume_from = None
+workflow = [('train', 1)]
+
+# disable opencv multithreading to avoid system being overloaded
+opencv_num_threads = 0
+# set multi-process start method as `fork` to speed up the training
+mp_start_method = 'fork'

--- a/mmdetection/configs/Inseo15/schedule.py
+++ b/mmdetection/configs/Inseo15/schedule.py
@@ -1,0 +1,26 @@
+# optimizer
+optimizer_config = dict(grad_clip=None)
+
+optimizer = dict(
+    type='AdamW',
+    lr=0.0001,
+    betas=(0.9, 0.999),
+    weight_decay=0.05,
+    paramwise_cfg=dict(
+        custom_keys={
+            'absolute_pos_embed': dict(decay_mult=0.),
+            'relative_position_bias_table': dict(decay_mult=0.),
+            'norm': dict(decay_mult=0.)
+            }
+        )
+    )
+
+# learning policy
+lr_config = dict(
+    policy='step',
+    warmup='linear',
+    warmup_iters=1000,
+    warmup_ratio=0.001,
+    step=4,
+    gamma=0.6)
+runner = dict(type='EpochBasedRunner', max_epochs=36)


### PR DESCRIPTION
## 사용 모델 및 구조

cascade RCNN
swinL

## 리더보드 점수 및 로컬 점수
LBscore 0.6720

## 사용 방법
기존과 동일합니다.
이를 베이스로 fold만 바꿔서 학습시키면 됩니다!
현재 0, 3, 9는 진행했습니다.

dataset.py에서 fold 번호만 바꿔서 진행하시면 됩니다.
![image](https://user-images.githubusercontent.com/64190071/161426217-2af0072d-cdeb-464a-a5cd-b0e8fdba7593.png)

이후 파일 이름도 바꾸신 후, wandb 설정 마치신 후 진행하시면 됩니다!
![image](https://user-images.githubusercontent.com/64190071/161426236-24a3c1b9-edc4-40f0-a6b1-c664f3c22865.png)

